### PR TITLE
Fix spacing of fields in left panel

### DIFF
--- a/OneDrive/Escritorio/Programas/hc415/tramsent.py
+++ b/OneDrive/Escritorio/Programas/hc415/tramsent.py
@@ -1195,7 +1195,10 @@ class SentenciaWidget(QWidget):
         self.left_container = QWidget()
         self.left_layout    = QVBoxLayout(self.left_container)
         # Compactamos el espacio vertical en el panel izquierdo
-        self.left_layout.setSpacing(4)
+        self.left_layout.setSpacing(2)
+        # Mantenemos los campos pegados al inicio para evitar que se
+        # distribuyan por toda la altura disponible
+        self.left_layout.setAlignment(Qt.AlignTop)
         self.toolbox = QToolBox()
         self.left_layout.addWidget(self.toolbox)
         self.left_scroll.setWidget(self.left_container)
@@ -1280,7 +1283,7 @@ class SentenciaWidget(QWidget):
         general_layout.setColumnStretch(1, 3)
         general_layout.setColumnStretch(2, 1)
         # Menor espacio vertical entre filas para compactar el formulario
-        general_layout.setVerticalSpacing(2)
+        general_layout.setVerticalSpacing(1)
 
         row = 0
         lbl_loc = QLabel("Localidad:")
@@ -1337,7 +1340,7 @@ class SentenciaWidget(QWidget):
         imp_layout = QGridLayout(imputados_page)
         imp_layout.setColumnStretch(0, 1)
         imp_layout.setColumnStretch(1, 3)
-        imp_layout.setVerticalSpacing(2)
+        imp_layout.setVerticalSpacing(1)
 
         row = 0
         lbl_numimp = QLabel("Número de imputados:")
@@ -1358,7 +1361,7 @@ class SentenciaWidget(QWidget):
         hechos_layout = QGridLayout(hechos_page)
         hechos_layout.setColumnStretch(0, 1)
         hechos_layout.setColumnStretch(1, 3)
-        hechos_layout.setVerticalSpacing(2)
+        hechos_layout.setVerticalSpacing(1)
 
         row = 0
         lbl_numhec = QLabel("Número de hechos:")
@@ -1380,7 +1383,7 @@ class SentenciaWidget(QWidget):
         extra_layout.setColumnStretch(0, 1)
         extra_layout.setColumnStretch(1, 3)
         extra_layout.setColumnStretch(2, 1)
-        extra_layout.setVerticalSpacing(2)
+        extra_layout.setVerticalSpacing(1)
 
         row = 0
         lbl_sujev = QLabel("Sujeto eventual:")
@@ -1643,6 +1646,8 @@ class SentenciaWidget(QWidget):
             idx = len(self.imputados) + 1
             container = QWidget()
             layout = QGridLayout(container)
+            layout.setVerticalSpacing(1)
+            layout.setVerticalSpacing(1)
             lbl_nombre = QLabel(f"Imputado/a #{idx} - Nombre:")
             le_nombre = QLineEdit()
             layout.addWidget(lbl_nombre, 0, 0)


### PR DESCRIPTION
## Summary
- compress vertical spacing in UI layouts in `tramsent.py`
- keep widgets aligned to the top so forms don't stretch vertically

## Testing
- `python3 -m py_compile OneDrive/Escritorio/Programas/hc415/tramsent.py`