### PR TITLE
Enhance collapsible groups appearance

### DIFF
--- a/OneDrive/Escritorio/Programas/hc415/tramsent.py
+++ b/OneDrive/Escritorio/Programas/hc415/tramsent.py
@@ -14,7 +14,8 @@ from functools import partial
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QLabel, QLineEdit, QTextEdit,
     QComboBox, QSpinBox, QRadioButton, QButtonGroup, QPushButton,
-    QGridLayout, QVBoxLayout, QHBoxLayout, QScrollArea, QDialog, QDialogButtonBox, QSizePolicy, QToolBox
+    QGridLayout, QVBoxLayout, QHBoxLayout, QScrollArea, QDialog,
+    QDialogButtonBox, QSizePolicy, QToolButton, QFrame, QStyle
 )
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QIcon
@@ -324,6 +325,42 @@ ORDINALES_HECHOS = [
     "Decimocuarto",
     "Decimoquinto"
 ]
+
+
+class CollapsibleGroup(QFrame):
+    """Sección expandible con encabezado de botón."""
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent)
+        self.setFrameShape(QFrame.StyledPanel)
+        self.setStyleSheet(
+            "QFrame {"
+            "  border: 1px solid #cccccc;"
+            "  border-radius: 4px;"
+            "  background: #f7f7f7;"
+            "}"
+        )
+
+        self.toggle_button = QToolButton(text=title, checkable=True)
+        self.toggle_button.setChecked(False)
+        self.toggle_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.toggle_button.setIcon(self.style().standardIcon(QStyle.SP_ArrowRight))
+        self.toggle_button.setStyleSheet("QToolButton { border: none; }")
+        self.toggle_button.clicked.connect(self._on_toggled)
+
+        self.content_area = QWidget()
+        self.content_area.setVisible(False)
+
+        lay = QVBoxLayout(self)
+        lay.setSpacing(0)
+        lay.setContentsMargins(4, 4, 4, 4)
+        lay.addWidget(self.toggle_button)
+        lay.addWidget(self.content_area)
+
+    def _on_toggled(self, checked: bool):
+        icon = QStyle.SP_ArrowDown if checked else QStyle.SP_ArrowRight
+        self.toggle_button.setIcon(self.style().standardIcon(icon))
+        self.content_area.setVisible(checked)
 
 
 class SentenciaWidget(QWidget):
@@ -1199,8 +1236,16 @@ class SentenciaWidget(QWidget):
         # Mantenemos los campos pegados al inicio para evitar que se
         # distribuyan por toda la altura disponible
         self.left_layout.setAlignment(Qt.AlignTop)
-        self.toolbox = QToolBox()
-        self.left_layout.addWidget(self.toolbox)
+        # Grupos colapsables al estilo del explorador de archivos
+        self.general_group = CollapsibleGroup("Datos generales")
+        self.imputados_group = CollapsibleGroup("Imputados")
+        self.hechos_group = CollapsibleGroup("Hechos")
+        self.extra_group = CollapsibleGroup("Otras opciones")
+
+        for grp in (self.general_group, self.imputados_group,
+                    self.hechos_group, self.extra_group):
+            self.left_layout.addWidget(grp)
+
         self.left_scroll.setWidget(self.left_container)
         # Reducimos el ancho mínimo para que la interfaz sea visible incluso
         # cuando la ventana no está en pantalla completa
@@ -1277,7 +1322,7 @@ class SentenciaWidget(QWidget):
         # ------------------------------------------------------------------
         #  Resto de tu configuración del formulario (idéntica a la tuya)
         # ------------------------------------------------------------------
-        general_page = QWidget()
+        general_page = self.general_group.content_area
         general_layout = QGridLayout(general_page)
         general_layout.setColumnStretch(0, 1)
         general_layout.setColumnStretch(1, 3)
@@ -1334,12 +1379,11 @@ class SentenciaWidget(QWidget):
         general_layout.addWidget(lbl_dia, row, 0)
         general_layout.addWidget(self.var_dia_audiencia, row, 1)
         row += 1
-        # Evitamos que el layout distribuya el espacio extra entre las filas
-        general_layout.setRowStretch(row, 1)
 
-        self.toolbox.addItem(general_page, "Datos generales")
+        # Contenido del grupo "Datos generales"
+        self.general_group.content_area.setLayout(general_layout)
 
-        imputados_page = QWidget()
+        imputados_page = self.imputados_group.content_area
         imp_layout = QGridLayout(imputados_page)
         imp_layout.setColumnStretch(0, 1)
         imp_layout.setColumnStretch(1, 3)
@@ -1358,11 +1402,10 @@ class SentenciaWidget(QWidget):
         self.imputados_layout = QVBoxLayout(self.imputados_container)
         imp_layout.addWidget(self.imputados_container, row, 0, 1, 2)
         row += 1
-        imp_layout.setRowStretch(row, 1)
 
-        self.toolbox.addItem(imputados_page, "Imputados")
+        self.imputados_group.content_area.setLayout(imp_layout)
 
-        hechos_page = QWidget()
+        hechos_page = self.hechos_group.content_area
         hechos_layout = QGridLayout(hechos_page)
         hechos_layout.setColumnStretch(0, 1)
         hechos_layout.setColumnStretch(1, 3)
@@ -1381,11 +1424,10 @@ class SentenciaWidget(QWidget):
         self.hechos_layout = QVBoxLayout(self.hechos_container)
         hechos_layout.addWidget(self.hechos_container, row, 0, 1, 2)
         row += 1
-        hechos_layout.setRowStretch(row, 1)
 
-        self.toolbox.addItem(hechos_page, "Hechos")
+        self.hechos_group.content_area.setLayout(hechos_layout)
 
-        extra_page = QWidget()
+        extra_page = self.extra_group.content_area
         extra_layout = QGridLayout(extra_page)
         extra_layout.setColumnStretch(0, 1)
         extra_layout.setColumnStretch(1, 3)
@@ -1479,9 +1521,8 @@ class SentenciaWidget(QWidget):
         self.btn_resuelvo = QPushButton("Editar resuelvo")
         extra_layout.addWidget(self.btn_resuelvo, row, 1)
         row += 1
-        extra_layout.setRowStretch(row, 1)
 
-        self.toolbox.addItem(extra_page, "Otras opciones")
+        self.extra_group.content_area.setLayout(extra_layout)
 
         self.data.apply_to_sentencia(self)
 
@@ -1754,7 +1795,6 @@ class SentenciaWidget(QWidget):
             # Lo agregamos al layout, igual que 'datos' y 'condiciones':
             layout.addWidget(lbl_pautas, 13, 0)
             layout.addWidget(btn_pautas, 13, 1, 1, 3)
-            layout.setRowStretch(layout.rowCount(), 1)
 
             if idx-1 < len(self.data.imputados):
                 dprev = self.data.imputados[idx-1]
@@ -1845,7 +1885,6 @@ class SentenciaWidget(QWidget):
             le_fec = QLineEdit()
             layout.addWidget(lbl_fec, next_row, 0)
             layout.addWidget(le_fec, next_row, 1, 1, 1)
-            layout.setRowStretch(layout.rowCount(), 1)
 
             container.setLayout(layout)
             self.hechos_layout.addWidget(container)


### PR DESCRIPTION
## Summary
- style collapsible sections with borders and background
- show arrow icons indicating expanded/collapsed state
- remove row stretching so groups stack tightly

## Testing
- `python -m py_compile app.py core_data.py main.py sentencia_window.py tramsent.py`
