### PR TITLE
Show confirmation dialog after saving DOCX

### DIFF
--- a/OneDrive/Escritorio/Programas/hc415/tramsent.py
+++ b/OneDrive/Escritorio/Programas/hc415/tramsent.py
@@ -1605,7 +1605,11 @@ class SentenciaWidget(QWidget):
         )
         if ruta:
             document.save(ruta)
-            print("Documento guardado en:", ruta)
+            QMessageBox.information(
+                self,
+                "Guardado",
+                f"Documento guardado en:\n{ruta}",
+            )
 
     def setup_connections(self):
         # Conexiones


### PR DESCRIPTION
## Summary
- display `QMessageBox` when a DOCX is generated to confirm the saved file path

## Testing
- `pytest -q` *(no tests found)*