### PR TITLE
Fix anchor editing conflicts

### DIFF
--- a/OneDrive/Escritorio/Programas/hc415/sentencia_window.py
+++ b/OneDrive/Escritorio/Programas/hc415/sentencia_window.py
@@ -38,13 +38,15 @@ class SentenciaWindow(QMainWindow):
         self.move(geo.topLeft())                                     # la llevamos allí
 
     def closeEvent(self, ev):
+        sw = self.centralWidget()
+        if hasattr(sw, "data"):
+            sw.data.from_sentencia(sw)
+
         if self.skip_confirm:
             ev.accept()
-            # si tenés main_win, lo mostramos
-            if hasattr(self, 'main_win'):
+            if hasattr(self, "main_win"):
                 self.main_win.show()
             else:
-                # fallback a la lógica original
                 self.parent().show()
         else:
             confirm_and_quit(self)


### PR DESCRIPTION
## Summary
- add `_edit_combo_box` dialog for combo fields
- use combo editor when clicking tribunal and sala anchors
- save Sentencia data on window close
- clean duplicated imports

## Testing
- `python -m py_compile OneDrive/Escritorio/Programas/hc415/tramsent.py OneDrive/Escritorio/Programas/hc415/sentencia_window.py`


------
https://chatgpt.com/codex/tasks/task_b_683a4ce71f60832289a5065f711689dc