### PR TITLE
Fix dialog close clearing template

### DIFF
--- a/OneDrive/Escritorio/Programas/hc415/tramsent.py
+++ b/OneDrive/Escritorio/Programas/hc415/tramsent.py
@@ -981,8 +981,8 @@ class SentenciaWidget(QWidget):
 
         btn_box.accepted.connect(_on_ok)
         btn_box.rejected.connect(dlg.reject)
-        dlg.rejected.connect(self.actualizar_plantilla)
         dlg.exec()
+        self._clear_highlight()
 
     def _rich_text_dialog(self, title: str, initial_html: str, on_accept_callback):
         """
@@ -1044,8 +1044,8 @@ class SentenciaWidget(QWidget):
 
         btn_box.accepted.connect(_on_ok)
         btn_box.rejected.connect(dlg.reject)
-        dlg.rejected.connect(self.actualizar_plantilla)
         dlg.exec()
+        self._clear_highlight()
 
     # ──────────────────────────────────────────────────────────────
     def _abrir_editor_rich_sobre_lineedit(self, qle: QLineEdit, titulo: str):
@@ -1104,8 +1104,8 @@ class SentenciaWidget(QWidget):
 
         btn_box.accepted.connect(_on_ok)
         btn_box.rejected.connect(dlg.reject)
-        dlg.rejected.connect(self.actualizar_plantilla)
         dlg.exec()
+        self._clear_highlight()
 
     # ──────────────────────────────────────────────────────────────
     def copiar_sentencia(self, te: QTextEdit) -> None:


### PR DESCRIPTION
## Summary
- prevent clearing the template when closing rich text dialogs

## Testing
- `python -m py_compile OneDrive/Escritorio/Programas/hc415/*.py`

------
https://chatgpt.com/codex/tasks/task_b_683a51c65c208322962e4ae6990cd4f8