### PR TITLE
Fix invisible Resuelvo placeholder

### DIFF
--- a/tramsent.py
+++ b/tramsent.py
@@ -3577,7 +3577,7 @@ class SentenciaWidget(QWidget):
         # ── Resuelvo ───────────────────────────────────────────
         html_resuelvo = self.var_resuelvo.property("html") or ""
         if not html_resuelvo.strip():
-            html_anchor = anchor_html("", "resuelvo", "resuelvo")
+            html_anchor = anchor_html("", "resuelvo")
         else:
             if not re.search(r"<p\b", html_resuelvo, flags=re.I):
                 html_resuelvo = f"<p>{html_resuelvo}</p>"


### PR DESCRIPTION
## Summary
- show `[resuelvo]` placeholder when no text is provided

## Testing
- `python3 -m py_compile tramsent.py main.py core_data.py sentencia_window.py widgets.py app.py`

------
https://chatgpt.com/codex/tasks/task_b_683b4ed4e938832297a99b294520d922