### PR TITLE
Fix missing resuelvo placeholder

### DIFF
--- a/OneDrive/Escritorio/Programas/hc415/tramsent.py
+++ b/OneDrive/Escritorio/Programas/hc415/tramsent.py
@@ -3535,9 +3535,13 @@ class SentenciaWidget(QWidget):
 
         # ── Resuelvo ───────────────────────────────────────────
         html_resuelvo = self.var_resuelvo.property("html") or ""
-        if html_resuelvo:
-            html_resuelvo = f'<a href="resuelvo" style="background-color:#ffffcc;color:black;text-decoration:none;">{html_resuelvo}</a>'
-            plantilla += f"<p align='justify'>{html_resuelvo}</p>"
+        if not html_resuelvo.strip():
+            html_anchor = anchor_html("", "resuelvo")
+        else:
+            if not re.search(r"<p\b", html_resuelvo, flags=re.I):
+                html_resuelvo = f"<p>{html_resuelvo}</p>"
+            html_anchor = anchor_html(html_resuelvo, "resuelvo")
+        plantilla += html_anchor
 
         plantilla = f'<div style="text-align: justify;">{plantilla}</div>'
 


### PR DESCRIPTION
## Summary
- ensure `[resuelvo]` link always shows by anchoring empty resuelvo text

## Testing
- `python3 -m py_compile OneDrive/Escritorio/Programas/hc415/tramsent.py tramsent.py`

------
https://chatgpt.com/codex/tasks/task_b_683b5002748c8322b76470f79915fbbe