### PR TITLE
Fix hechos rebuild behavior

### DIFF
--- a/core_data.py
+++ b/core_data.py
@@ -178,7 +178,9 @@ class CausaData:
 
         # --- Hechos ---
         if hasattr(win, "spin_hechos"):
+            was_blocked = win.spin_hechos.blockSignals(True)
             win.spin_hechos.setValue(self.num_hechos or len(self.hechos) or 1)
+            win.spin_hechos.blockSignals(was_blocked)
             win.rebuild_hechos()
             for idx, datos in enumerate(self.hechos):
                 if idx >= len(win.hechos_widgets):

--- a/main.py
+++ b/main.py
@@ -395,7 +395,7 @@ class MainWindow(QMainWindow):
 
         label("Número de hechos:")
         self.spin_hechos = NoWheelSpinBox(); self.spin_hechos.setRange(1, 15)
-        self.spin_hechos.valueChanged.connect(self.rebuild_hechos)
+        self.spin_hechos.valueChanged.connect(self._on_hechos_changed)
         self.form.addWidget(self.spin_hechos, self._row, 1); self._row += 1
 
         self.tabs_hechos = QTabWidget()
@@ -758,6 +758,13 @@ class MainWindow(QMainWindow):
                 le_fec.setText(dato.get("fecha_elev", ""))
 
         self._building_hechos = False
+        # ``update_template`` se llamará únicamente cuando el usuario cambie
+        # manualmente la cantidad de hechos para evitar recursividad indeseada
+        # al reconstruir desde ``apply_to_main``.
+
+    def _on_hechos_changed(self, _=None):
+        """Actualiza pestañas y plantilla tras un cambio del usuario."""
+        self.rebuild_hechos()
         self.update_template()
 
     def abrir_ventana_resuelvo(self):


### PR DESCRIPTION
## Summary
- prevent update loops when rebuilding hechos
- trigger template update only on user changes
- block signals when setting hechos count programmatically

## Testing
- `python -m py_compile main.py core_data.py`

------
https://chatgpt.com/codex/tasks/task_b_683b7c52c19c83228116be34492f9372