### PR TITLE
Fix description preview truncation

### DIFF
--- a/OneDrive/Escritorio/Programas/hc415/tramsent.py
+++ b/OneDrive/Escritorio/Programas/hc415/tramsent.py
@@ -1057,7 +1057,7 @@ class SentenciaWidget(QWidget):
             html_inicial,
             lambda html_limpio: (
                 qle.setProperty("html", html_limpio),
-                qle.setText(QTextDocument(html_limpio).toPlainText()[:200]),
+                qle.setText(QTextDocument(html_limpio).toPlainText().replace("\n", " ")),
                 self.actualizar_plantilla(),
             ),
         )
@@ -1250,7 +1250,7 @@ class SentenciaWidget(QWidget):
         """Guarda `html` aplanado en property('html') y preview plano en el LineEdit."""
         h = self._flatten_inline(html)
         qlineedit.setProperty("html", h)
-        qlineedit.setText(QTextDocument(h).toPlainText()[:200])
+        qlineedit.setText(QTextDocument(h).toPlainText().replace("\n", " "))
         self.actualizar_plantilla()
 
     def abrir_ventana_descripcion(self, idx):
@@ -1369,7 +1369,7 @@ class SentenciaWidget(QWidget):
         # 2) genero preview plano en el QLineEdit
         doc = QTextDocument()
         doc.setHtml(clean)
-        preview = doc.toPlainText().replace("\n", " ")[:200]
+        preview = doc.toPlainText().replace("\n", " ")
         self.var_decomiso_text.setText(preview)
         # 3) refresco la plantilla
         self.actualizar_plantilla()
@@ -1379,7 +1379,7 @@ class SentenciaWidget(QWidget):
         self.var_restriccion_text.setProperty("html", clean)
         doc = QTextDocument()
         doc.setHtml(clean)
-        preview = doc.toPlainText().replace("\n", " ")[:200]
+        preview = doc.toPlainText().replace("\n", " ")
         self.var_restriccion_text.setText(preview)
         self.actualizar_plantilla()
 
@@ -1434,7 +1434,7 @@ class SentenciaWidget(QWidget):
 
         doc = QTextDocument()
         doc.setHtml(clean)
-        preview = doc.toPlainText().replace("\n", " ")[:200]
+        preview = doc.toPlainText().replace("\n", " ")
         self.var_resuelvo.setText(preview)
 
         # 3) ***ACTUALIZO el modelo compartido***

--- a/core_data.py
+++ b/core_data.py
@@ -189,7 +189,7 @@ class CausaData:
                 w["descripcion"].setProperty("html", datos.get("descripcion", ""))
                 from PySide6.QtGui import QTextDocument
                 doc = QTextDocument(); doc.setHtml(datos.get("descripcion", ""))
-                w["descripcion"].setText(doc.toPlainText()[:200])
+                w["descripcion"].setText(doc.toPlainText().replace("\n", " "))
                 w["aclaraciones"].setText(datos.get("aclaraciones", ""))
                 w["oficina"].setText(datos.get("oficina", ""))
                 if datos.get("juzgado", True):
@@ -358,7 +358,7 @@ class CausaData:
             w["descripcion"].setProperty("html", datos_hec.get("descripcion", ""))
             from PySide6.QtGui import QTextDocument
             doc = QTextDocument(); doc.setHtml(datos_hec.get("descripcion", ""))
-            w["descripcion"].setText(doc.toPlainText()[:200])
+            w["descripcion"].setText(doc.toPlainText().replace("\n", " "))
             w["aclaraciones"].setText(datos_hec.get("aclaraciones", ""))
             w["oficina"].setText(datos_hec.get("oficina", ""))
             if datos_hec.get("juzgado", True):

--- a/main.py
+++ b/main.py
@@ -749,7 +749,7 @@ class MainWindow(QMainWindow):
                 dato = self.data.hechos[i-1]
                 le_desc.setProperty("html", dato.get("descripcion", ""))
                 doc = QTextDocument(); doc.setHtml(dato.get("descripcion", ""))
-                le_desc.setText(doc.toPlainText()[:200])
+                le_desc.setText(doc.toPlainText().replace("\n", " "))
                 le_aclar.setText(dato.get("aclaraciones", ""))
                 le_ofi.setText(dato.get("oficina", ""))
                 rb_j.setChecked(dato.get("juzgado", True))
@@ -795,7 +795,7 @@ class MainWindow(QMainWindow):
         clean = html.strip()
         qlineedit.setProperty("html", clean)
         doc = QTextDocument(); doc.setHtml(clean)
-        qlineedit.setText(doc.toPlainText()[:200])
+        qlineedit.setText(doc.toPlainText().replace("\n", " "))
         self.update_template()
 
     def abrir_ventana_hecho_desc(self, idx: int):

--- a/tramsent.py
+++ b/tramsent.py
@@ -1193,7 +1193,7 @@ class SentenciaWidget(QWidget):
             html_inicial,
             lambda html_limpio: (
                 qle.setProperty("html", html_limpio),
-                qle.setText(QTextDocument(html_limpio).toPlainText()[:200]),
+                qle.setText(QTextDocument(html_limpio).toPlainText().replace("\n", " ")),
                 self.actualizar_plantilla(),
             ),
         )
@@ -1426,7 +1426,7 @@ class SentenciaWidget(QWidget):
         """Guarda `html` aplanado en property('html') y preview plano en el LineEdit."""
         h = self._flatten_inline(html)
         qlineedit.setProperty("html", h)
-        qlineedit.setText(QTextDocument(h).toPlainText()[:200])
+        qlineedit.setText(QTextDocument(h).toPlainText().replace("\n", " "))
         self.actualizar_plantilla()
 
     def abrir_ventana_descripcion(self, idx):
@@ -1545,7 +1545,7 @@ class SentenciaWidget(QWidget):
         # 2) genero preview plano en el QLineEdit
         doc = QTextDocument()
         doc.setHtml(clean)
-        preview = doc.toPlainText().replace("\n", " ")[:200]
+        preview = doc.toPlainText().replace("\n", " ")
         self.var_decomiso_text.setText(preview)
         # 3) refresco la plantilla
         self.actualizar_plantilla()
@@ -1555,7 +1555,7 @@ class SentenciaWidget(QWidget):
         self.var_restriccion_text.setProperty("html", clean)
         doc = QTextDocument()
         doc.setHtml(clean)
-        preview = doc.toPlainText().replace("\n", " ")[:200]
+        preview = doc.toPlainText().replace("\n", " ")
         self.var_restriccion_text.setText(preview)
         self.actualizar_plantilla()
 
@@ -1610,7 +1610,7 @@ class SentenciaWidget(QWidget):
 
         doc = QTextDocument()
         doc.setHtml(clean)
-        preview = doc.toPlainText().replace("\n", " ")[:200]
+        preview = doc.toPlainText().replace("\n", " ")
         self.var_resuelvo.setText(preview)
 
         # 3) ***ACTUALIZO el modelo compartido***


### PR DESCRIPTION
## Summary
- avoid truncating event descriptions in MainWindow
- sync corresponding display logic in model and sentencing widgets

## Testing
- `python -m py_compile main.py core_data.py tramsent.py sentencia_window.py widgets.py OneDrive/Escritorio/Programas/hc415/main.py OneDrive/Escritorio/Programas/hc415/core_data.py OneDrive/Escritorio/Programas/hc415/tramsent.py OneDrive/Escritorio/Programas/hc415/sentencia_window.py OneDrive/Escritorio/Programas/hc415/widgets.py`


------
https://chatgpt.com/codex/tasks/task_b_683b7e06ef0883229874e5c04d489987