### PR TITLE
Bugfix: avoid freezing hechos fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -720,9 +720,9 @@ class MainWindow(QMainWindow):
             le_fec = QLineEdit(); add_pair("Fecha de elevación:", le_fec)
 
             for w in [le_desc, le_aclar, le_ofi, le_auto, le_fec]:
-                w.textChanged.connect(self.update_template)
+                w.textChanged.connect(self.update)
             for w in [rb_j, rb_f]:
-                w.toggled.connect(self.update_template)
+                w.toggled.connect(self.update)
 
             self.tabs_hechos.addTab(tab, f"Hecho {i}")
             self.hechos_widgets.append({


### PR DESCRIPTION
## Summary
- connect hechos field signals to `update` instead of `update_template`

## Testing
- `python -m py_compile main.py core_data.py tramsent.py sentencia_window.py widgets.py app.py`


------
https://chatgpt.com/codex/tasks/task_b_683b832b1d9c8322851f5f3c5f0b547e